### PR TITLE
Add possibility to define custom HTTP headers for querying introspection schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ All plugin options and their defaults:
     <generateIntrospectionFile>false</generateIntrospectionFile>
     <sourceDirName>${project.basedir}/src/main/graphql</sourceDirName>
     <schemaUrl>http://localhost/graphql</schemaUrl>
+    <schemaUrlHeaders></schemaUrlHeaders>
     <rootPackageName>com.example.graphql.client</rootPackageName>
     <outputDirectory>${project.build.directory}/generated-sources/graphql-client</outputDirectory>
     <generateModelBuilder>true</generateModelBuilder>

--- a/apollo-client-maven-plugin/src/main/kotlin/com/lahzouz/java/graphql/client/maven/plugin/GraphQLClientMojo.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/lahzouz/java/graphql/client/maven/plugin/GraphQLClientMojo.kt
@@ -47,6 +47,9 @@ class GraphQLClientMojo : AbstractMojo() {
     @Parameter(property = "schemaUrl", defaultValue = "http://localhost/graphql")
     private lateinit var schemaUrl: String
 
+    @Parameter(property = "schemaUrlHeaders")
+    private var customHeaders: Map<String, String> = emptyMap()
+
     @Parameter(property = "sourceDirName", defaultValue = "\${project.basedir}/src/main/graphql")
     private lateinit var sourceDirName: String
 
@@ -116,7 +119,7 @@ class GraphQLClientMojo : AbstractMojo() {
 
         if (generateIntrospectionFile) {
             log.info("Automatically generating introspection file from $schemaUrl")
-            val schema = getIntrospectionSchema(schemaUrl)
+            val schema = getIntrospectionSchema(schemaUrl, customHeaders)
             if (schema.isNotEmpty()) {
                 File(introspectionFile.toURI()).writeText(schema)
             } else {

--- a/apollo-client-maven-plugin/src/main/kotlin/com/lahzouz/java/graphql/client/maven/plugin/Introspection.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/lahzouz/java/graphql/client/maven/plugin/Introspection.kt
@@ -11,7 +11,7 @@ import java.nio.charset.Charset
 
 object Introspection {
 
-    fun getIntrospectionSchema(host: String): String {
+    fun getIntrospectionSchema(host: String, customHeaders: Map<String, String>): String {
         val client = HttpClients.custom()
                 .disableContentCompression()
                 .build()
@@ -25,6 +25,7 @@ object Introspection {
             setHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, identity")
             setHeader(HttpHeaders.ACCEPT_CHARSET, "utf-8")
             setHeader(HttpHeaders.USER_AGENT, "Apollo Client Maven Plugin")
+            customHeaders.forEach { (name, value) -> setHeader(name, value) }
         }
         val response = client.execute(request)
         var schema = ""


### PR DESCRIPTION
This PR adds posibility to define additional request headers that are added when querying for introspection schema by `schemaUrl`.

This enhancement was needed for usecase where GraphQL endpoint requires authentication via e.g. API token – that was our case, with the need to pass header `X-Api-Key`.