### PR TITLE
feat!: upgrade to Apollo Kotlin 3.8.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -118,7 +118,7 @@ All plugin configuration properties and their defaults:
                     <rootFolders>
                         <rootFolder>${project.basedir}/src/main/graphql/lahzouz/</rootFolder>
                     </rootFolders>
-                    <customScalarsMapping></customScalarsMapping>
+                    <scalarsMapping></scalarsMapping>
                     <operationIdGeneratorClass></operationIdGeneratorClass>
                     <schemaPackageName>com.lahzouz.apollo.graphql.client</schemaPackageName>
                     <packageName>com.lahzouz.apollo.graphql.client</packageName>
@@ -134,7 +134,9 @@ All plugin configuration properties and their defaults:
                     <generateResponseFields>false</generateResponseFields>
                     <generateSchema>false</generateSchema>
                     <generateTestBuilders>false</generateTestBuilders>
-                    <moduleName>apollographql</moduleName>
+                    <generateDataBuilders>false</generateDataBuilders>
+                    <generateModelBuilders>false</generateModelBuilders>
+                    <nullableFieldStyle>NONE</nullableFieldStyle>
                     <useSemanticNaming>true</useSemanticNaming>
                     <targetLanguage>JAVA</targetLanguage>
                     <sealedClassesForEnumsMatching></sealedClassesForEnumsMatching>
@@ -180,9 +182,9 @@ define mapping configuration then register your custom adapter:
 ----
 <configuration>
     ...
-    <customScalarsMapping>
+    <scalarsMapping>
         <Long>java.time.LocalDate</Long>
-    </customScalarsMapping>
+    </scalarsMapping>
     ...
 </configuration>
 ----

--- a/apollo-client-maven-plugin-tests/pom.xml
+++ b/apollo-client-maven-plugin-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.aoudiamoncef</groupId>
         <artifactId>apollo-client-maven-plugin-parent</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>com.github.aoudiamoncef</groupId>
                 <artifactId>apollo-client-maven-plugin</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -141,9 +141,9 @@
                                                 <rootFolder>${project.basedir}/src/main/graphql/books/</rootFolder>
                                             </rootFolders>
                                             <generateKotlinModels>true</generateKotlinModels>
-                                            <customScalarsMapping>
+                                            <scalarsMapping>
                                                 <Long>java.lang.Long</Long>
-                                            </customScalarsMapping>
+                                            </scalarsMapping>
                                             <operationIdGeneratorClass></operationIdGeneratorClass>
                                             <schemaPackageName>com.lahzouz.apollo.graphql.client</schemaPackageName>
                                             <packageName>com.lahzouz.apollo.graphql.client</packageName>
@@ -159,8 +159,8 @@
                                             <generateTestBuilders>false</generateTestBuilders>
                                             <generateOptionalOperationVariables>false
                                             </generateOptionalOperationVariables>
+                                            <nullableFieldStyle>NONE</nullableFieldStyle>
                                             <useSemanticNaming>true</useSemanticNaming>
-                                            <moduleName>apollographql</moduleName>
                                             <targetLanguage>KOTLIN_1_5</targetLanguage>
                                             <sealedClassesForEnumsMatching></sealedClassesForEnumsMatching>
                                             <alwaysGenerateTypesMatching></alwaysGenerateTypesMatching>

--- a/apollo-client-maven-plugin/pom.xml
+++ b/apollo-client-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.aoudiamoncef</groupId>
         <artifactId>apollo-client-maven-plugin-parent</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/GraphQLClientMojo.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/GraphQLClientMojo.kt
@@ -140,6 +140,8 @@ class GraphQLClientMojo : AbstractMojo() {
 
             val metadata = compilerParams.metadataFiles.toList().map { ApolloMetadata.readFrom(it).compilerMetadata }
 
+            val scalarMapping = compilerParams.scalarsMapping.mapValues { ScalarInfo(it.value) }
+
             ApolloCompiler.write(
                 Options(
                     schema = resolveSchema!!.toSchema(),
@@ -153,7 +155,7 @@ class GraphQLClientMojo : AbstractMojo() {
                     alwaysGenerateTypesMatching = compilerParams.alwaysGenerateTypesMatching,
                     operationOutputGenerator = operationOutputGenerator,
                     incomingCompilerMetadata = metadata,
-                    customScalarsMapping = compilerParams.customScalarsMapping,
+                    scalarMapping = scalarMapping,
                     codegenModels = compilerParams.codegenModels.label,
                     flattenModels = compilerParams.flattenModels,
                     useSemanticNaming = compilerParams.useSemanticNaming,
@@ -166,9 +168,11 @@ class GraphQLClientMojo : AbstractMojo() {
                     generateResponseFields = compilerParams.generateResponseFields,
                     generateQueryDocument = compilerParams.generateQueryDocument,
                     generateSchema = compilerParams.generateSchema,
-                    moduleName = compilerParams.moduleName,
                     targetLanguage = compilerParams.targetLanguage,
                     generateTestBuilders = compilerParams.generateTestBuilders,
+                    generateModelBuilders = compilerParams.generateModelBuilders,
+                    generateDataBuilders = compilerParams.generateDataBuilders,
+                    nullableFieldStyle = compilerParams.nullableFieldStyle,
                     sealedClassesForEnumsMatching = compilerParams.sealedClassesForEnumsMatching,
                     generateOptionalOperationVariables = compilerParams.generateOptionalOperationVariables
                 )

--- a/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/config/CompilerParams.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/config/CompilerParams.kt
@@ -38,7 +38,7 @@ class CompilerParams {
      *
      * Default value: the empty map
      */
-    var customScalarsMapping: Map<String, String> = emptyMap()
+    var scalarsMapping: Map<String, String> = emptyMap()
 
     /**
      * By default, Apollo uses `Sha256` hashing algorithm to generate an ID for the query.
@@ -199,6 +199,43 @@ class CompilerParams {
      */
     internal val generateTestBuilders: Boolean = false
 
+    /**
+     * Whether to generate the type safe Data builders. These are mainly used for tests but can also be used for other use
+     * cases too.
+     *
+     * Only valid when [generateKotlinModels] is true
+     */
+    internal val generateDataBuilders: Boolean = false
+
+    /**
+     * Whether to generate builders for java models
+     *
+     * Default value: false
+     * Only valid when [generateKotlinModels] is false
+     */
+    internal val generateModelBuilders: Boolean = false
+
+    /**
+     * The style to use for fields that are nullable in the Java generated code.
+     *
+     * Only valid when [targetLanguage] is [TargetLanguage.JAVA]
+     *
+     * Acceptable values:
+     * - `none`: Fields will be generated with the same type whether they are nullable or not
+     * - `apolloOptional`: Fields will be generated as Apollo's `com.apollographql.apollo3.api.Optional<Type>` if nullable, or `Type` if not.
+     * - `javaOptional`: Fields will be generated as Java's `java.util.Optional<Type>` if nullable, or `Type` if not.
+     * - `guavaOptional`: Fields will be generated as Guava's `com.google.common.base.Optional<Type>` if nullable, or `Type` if not.
+     * - `jetbrainsAnnotations`: Fields will be generated with Jetbrain's `org.jetbrains.annotations.Nullable` annotation if nullable, or
+     * `org.jetbrains.annotations.NotNull` if not.
+     * - `androidAnnotations`: Fields will be generated with Android's `androidx.annotation.Nullable` annotation if nullable, or
+     * `androidx.annotation.NonNull` if not.
+     * - `jsr305Annotations`: Fields will be generated with JSR 305's `javax.annotation.Nullable` annotation if nullable, or
+     * `javax.annotation.Nonnull` if not.
+     *
+     * Default: `none`
+     */
+    internal val nullableFieldStyle: JavaNullable = JavaNullable.NONE
+
     // TODO to be handled
     /**
      * What codegen to use. One of "OPERATION", "RESPONSE" or "COMPATIBILITY"
@@ -214,11 +251,6 @@ class CompilerParams {
      * Default value: true for "operationBased" and "responseBased", false else
      */
     internal val flattenModels: Boolean = true
-
-    /**
-     * The moduleName for this metadata. Used for debugging purposes
-     */
-    internal val moduleName: String = "apollographql"
 
     internal val logger: ApolloCompiler.Logger = ApolloCompiler.NoOpLogger
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.aoudiamoncef</groupId>
     <artifactId>apollo-client-maven-plugin-parent</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0</version>
     <packaging>pom</packaging>
 
     <name>apollo-client-maven-plugin-parent</name>
@@ -30,7 +30,7 @@
 
         <annotations.version>23.0.0</annotations.version>
         <ant.version>1.10.12</ant.version>
-        <apollo.version>3.0.0</apollo.version>
+        <apollo.version>3.8.1</apollo.version>
         <assertj-core.version>3.22.0</assertj-core.version>
         <graphql-java-servlet.version>6.1.3</graphql-java-servlet.version>
         <graphql-java-tools.version>5.2.4</graphql-java-tools.version>


### PR DESCRIPTION
Upgrade to  [apollo-kotlin v3.8.0](https://github.com/apollographql/apollo-kotlin/releases/tag/v3.8.0)

New Options:
- `generateDataBuilders`
- `generateModelBuilders`
- `nullableFieldStyle`

Breaking Changes:
- Remove `moduleName`
  - I'm not sure what exactly this option did before but it is no longer in 3.8.0
- Rename `customScalarsMapping` to `scalarsMapping`
  - This is just to match the name of the option in the compiler 

---

Thank you so much for your work on this plugin! Let me know if this is something you want to support / if there is anything else I can do to get this merged!

