### PR TITLE
feat!: scalar mapping adapter + addTestSourceRoot

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,6 +90,7 @@ All plugin configuration properties and their defaults:
         <lahzouz-complete-api>
             <enabled>true</enabled>
             <addSourceRoot>true</addSourceRoot>
+            <addTestSourceRoot>false</addTestSourceRoot>
             <sourceFolder>${project.basedir}/src/main/graphql/lahzouz</sourceFolder>
             <schemaPath>${project.basedir}/src/main/graphql/lahzouz/schema.json</schemaPath>
             <includes>
@@ -193,24 +194,52 @@ Implementation of a custom adapter for `java.time.LocalDate`:
 
 [source,java]
 ----
-public class DateGraphQLAdapter implements Adapter<Date> {
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
-
+public class LocalDateGraphQLAdapter implements Adapter<LocalDate> {
     @Override
-    public Date fromJson(@NotNull final JsonReader jsonReader, @NotNull final CustomScalarAdapters customScalarAdapters) throws IOException {
-        try {
-            return DATE_FORMAT.parse(jsonReader.nextString());
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
+    public LocalDate fromJson(@NotNull final JsonReader reader, @NotNull final CustomScalarAdapters customScalarAdapters) throws IOException {
+        return LocalDate.parse(reader.nextString());
     }
 
     @Override
-    public void toJson(@NotNull final JsonWriter jsonWriter, @NotNull final CustomScalarAdapters customScalarAdapters, final Date date) throws IOException {
-        jsonWriter.value(DATE_FORMAT.format(date));
+    public void toJson(@NotNull final JsonWriter writer, @NotNull final CustomScalarAdapters customScalarAdapters, final LocalDate value) throws IOException {
+        writer.value(value.toString());
     }
 }
 ----
+
+[source,xml]
+----
+<configuration>
+    ...
+    <scalarsMapping>
+        <Date>
+            <targetName>java.time.LocalDate</targetName>
+            <expression>new com.example.LocalDateGraphQLAdapter()</expression>
+        </Date>
+    </scalarsMapping>
+    ...
+</configuration>
+----
+
+==== Test Sources
+
+To generate sources for tests:
+[source,xml]
+----
+<configuration>
+    ...
+    <addSourceRoot>false</addSourceRoot>
+    <addTestSourceRoot>true</addTestSourceRoot>
+    <compilationUnit>
+        <name>example</name>
+        <outputDirectory>${project.basedir}/target/generated-test-sources/apollo/example</outputDirectory>
+        <debugDirectory>${project.basedir}/target/generated-test-sources/apollo/example/debug</debugDirectory>
+        <testDirectory>${project.basedir}/target/generated-test-sources/apollo/example/debug</testDirectory>
+    <compilationUnit/>
+    ...
+</configuration>
+----
+
 
 === Using Apollo Client
 

--- a/apollo-client-maven-plugin-tests/pom.xml
+++ b/apollo-client-maven-plugin-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.aoudiamoncef</groupId>
         <artifactId>apollo-client-maven-plugin-parent</artifactId>
-        <version>6.0.0</version>
+        <version>7.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>com.github.aoudiamoncef</groupId>
                 <artifactId>apollo-client-maven-plugin</artifactId>
-                <version>6.0.0</version>
+                <version>7.0.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -142,7 +142,9 @@
                                             </rootFolders>
                                             <generateKotlinModels>true</generateKotlinModels>
                                             <scalarsMapping>
-                                                <Long>java.lang.Long</Long>
+                                                <Long>
+                                                    <targetName>java.lang.Long</targetName>
+                                                </Long>
                                             </scalarsMapping>
                                             <operationIdGeneratorClass></operationIdGeneratorClass>
                                             <schemaPackageName>com.lahzouz.apollo.graphql.client</schemaPackageName>

--- a/apollo-client-maven-plugin/pom.xml
+++ b/apollo-client-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.aoudiamoncef</groupId>
         <artifactId>apollo-client-maven-plugin-parent</artifactId>
-        <version>6.0.0</version>
+        <version>7.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/config/CompilerParams.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/config/CompilerParams.kt
@@ -38,7 +38,7 @@ class CompilerParams {
      *
      * Default value: the empty map
      */
-    var scalarsMapping: Map<String, String> = emptyMap()
+    var scalarsMapping: Map<String, ScalarMapping> = emptyMap()
 
     /**
      * By default, Apollo uses `Sha256` hashing algorithm to generate an ID for the query.

--- a/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/config/ScalarMapping.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/config/ScalarMapping.kt
@@ -1,0 +1,26 @@
+package com.github.aoudiamoncef.apollo.plugin.config
+
+/**
+ * ScalarMapping contains all the parameters needed to generate scalar mappings with the apollo compiler.
+ */
+class ScalarMapping {
+
+    /**
+     * The fully qualified Java or Kotlin name of the type the scalar is mapped to.
+     *
+     * For example: `com.example.Date`
+     */
+    internal lateinit var targetName: String
+
+    /**
+     * An expression that will be used by the codegen to get an adapter for the given scalar.
+     *
+     * For example in Kotlin:
+     * - `com.example.DateAdapter` (a top level property or object)
+     * - `com.example.DateAdapter` (create a new instance every time)
+     * Or in Java:
+     * - `com.example.DateAdapter.INSTANCE` (a top level property or object)
+     * - `new com.example.DateAdapter()` (create a new instance every time)
+     */
+    internal val expression: String? = null
+}

--- a/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/config/Service.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/github/aoudiamoncef/apollo/plugin/config/Service.kt
@@ -18,6 +18,11 @@ class Service {
     internal val addSourceRoot: Boolean = true
 
     /**
+     * Whether to add generated sources to root
+     */
+    internal val addTestSourceRoot: Boolean = false
+
+    /**
      * Configures the [CompilationUnit]
      */
     internal lateinit var compilationUnit: CompilationUnit

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.aoudiamoncef</groupId>
     <artifactId>apollo-client-maven-plugin-parent</artifactId>
-    <version>6.0.0</version>
+    <version>7.0.0</version>
     <packaging>pom</packaging>
 
     <name>apollo-client-maven-plugin-parent</name>


### PR DESCRIPTION
- Specify what Adapter should be used for scalarMappings

```java
public class LocalDateGraphQLAdapter implements Adapter<LocalDate> {
    @Override
    public LocalDate fromJson(@NotNull final JsonReader reader, @NotNull final CustomScalarAdapters customScalarAdapters) throws IOException {
        return LocalDate.parse(reader.nextString());
    }

    @Override
    public void toJson(@NotNull final JsonWriter writer, @NotNull final CustomScalarAdapters customScalarAdapters, final LocalDate value) throws IOException {
        writer.value(value.toString());
    }
}
```

```xml
<configuration>
    ...
    <scalarsMapping>
        <Date>
            <targetName>java.time.LocalDate</targetName>
            <expression>new com.example.LocalDateGraphQLAdapter()</expression>
        </Date>
    </scalarsMapping>
    ...
</configuration>
```

Generated adapter output:
```java
public enum TestScalars implements Adapter<TestScalarsQuery.TestScalars> {
    INSTANCE;

    private static final List<String> RESPONSE_NAMES = Arrays.asList("dateField");

    @Override
    public TestScalarsQuery.TestScalars fromJson(JsonReader reader,
        CustomScalarAdapters customScalarAdapters) throws IOException {
      LocalDate _dateField = null;
      OffsetDateTime _dateTimeField = null;

      loop:
      while(true) {
        switch (reader.selectName(RESPONSE_NAMES)) {
          case 1: _dateField = new com.example.LocalDateGraphQLAdapter().fromJson(reader, customScalarAdapters); break;
          default: break loop;
        }
      }

      Assertions.checkFieldNotMissing(_dateField, "dateField");

      return new TestScalarsQuery.TestScalars(
        _dateField
      );
    }

    @Override
    public void toJson(JsonWriter writer, CustomScalarAdapters customScalarAdapters,
        TestScalarsQuery.TestScalars value) throws IOException {

      writer.name("dateField");
      new com.example.LocalDateGraphQLAdapter().toJson(writer, customScalarAdapters, value.dateField);
    }
  }
```

- `<addTestSourceRoot>`:  When true, generated classes are added to the test source root

---

Unfortunately this is another breaking change for scalar mappings but now that we have the `ScalarMapping` class we should be able to support future apollo compiler features.

