### PR TITLE
Update apollo and kotlin version

### DIFF
--- a/apollo-client-maven-plugin-tests/pom.xml
+++ b/apollo-client-maven-plugin-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.aoudiamoncef</groupId>
         <artifactId>apollo-client-maven-plugin-parent</artifactId>
-        <version>7.1.0</version>
+        <version>7.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>com.github.aoudiamoncef</groupId>
                 <artifactId>apollo-client-maven-plugin</artifactId>
-                <version>7.1.0</version>
+                <version>7.2.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apollo-client-maven-plugin/pom.xml
+++ b/apollo-client-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.aoudiamoncef</groupId>
         <artifactId>apollo-client-maven-plugin-parent</artifactId>
-        <version>7.1.0</version>
+        <version>7.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-        <kotlin.version>1.8.20</kotlin.version>
+        <kotlin.version>1.9.21</kotlin.version>
         <java.version>1.8</java.version>
         <!--This contends with dokka and creates two javadoc jars...-->
         <maven.javadoc.skip>true</maven.javadoc.skip>
@@ -30,7 +30,7 @@
 
         <annotations.version>24.1.0</annotations.version>
         <ant.version>1.10.14</ant.version>
-        <apollo.version>3.8.2</apollo.version>
+        <apollo.version>3.8.4</apollo.version>
         <assertj-core.version>3.24.2</assertj-core.version>
         <graphql-java-servlet.version>6.1.3</graphql-java-servlet.version>
         <graphql-java-tools.version>5.2.4</graphql-java-tools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.aoudiamoncef</groupId>
     <artifactId>apollo-client-maven-plugin-parent</artifactId>
-    <version>7.1.0</version>
+    <version>7.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>apollo-client-maven-plugin-parent</name>


### PR DESCRIPTION
Many versions are quite old, is this intended? Dependabot has nearly no PRs.

Are there plans to support apollo version 4.0?

3.8.3 and 3.8.4 had no breaking changes. 1.9.21 is the version used in apollo, maybe we could directly use 1.9.24.